### PR TITLE
chore: let the convention plugin apply develocity

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 clikt = "5.0.2"
 dependencyAnalysis = "2.7.0"
-develocity = "3.19"
+develocity = "3.19.1"
 java = "17"
 junitJupiter = "5.11.4"
 junitPlatform = "1.11.4"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,8 +10,6 @@ pluginManagement {
 }
 
 plugins {
-  // Keep this version in sync with version catalog
-  id("com.gradle.develocity") version "3.19.1"
   id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
   id("block.settings")
 }


### PR DESCRIPTION
We're applying it two different ways with potentially two different versions. Better to let the convention plugin do it as it configures it as well.