### PR TITLE
docs: Update release note

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,41 +1,71 @@
 # Releasing Guide
-Release procedure for Kotlin Formatter
 
-1. Bump version number in `gradle.properties` to next stable version (removing the `-SNAPSHOT` suffix).
-2. Update CHANGELOG.md
-   1. Change the `Unreleased` header to the release version e.g. `[x.y.z] - YYYY-MM-DD`
+Release procedure for Kotlin Formatter.
+
+## 1. Prepare the Release
+
+1. Create a new branch for the release:
+   ```sh
+   git checkout -b release-x.y.z
+   ```
+
+2. Bump version number in `gradle.properties` to next stable version (removing the `-SNAPSHOT` suffix).
+3. Update `CHANGELOG.md`:
+   1. Change the `Unreleased` header to the release version e.g. `[x.y.z] - YYYY-MM-DD`.
    2. Add a new `Unreleased` section to the top.
-   ```md
-   ## [Unreleased]
+      ```md
+      ## [Unreleased]
 
-   ### New:
-   - Nothing yet!
+      ### New:
+      - Nothing yet!
 
-   ### Changed:
-   - Nothing yet!
+      ### Changed:
+      - Nothing yet!
 
-   ### Fixed:
-   - Nothing yet!
-   ```
+      ### Fixed:
+      - Nothing yet!
+      ```
 
-3. Update README.md if needed
-4. Commit
-   ```
+4. Update `README.md` if needed.
+5. Commit:
+   ```sh
    $ git commit -am "chore: prepare for release x.y.z."
    ```
-5. Tag
+
+6. Push the branch and create a pull request.
+
+## 2. Tag and Push the Release
+
+1. Once the PR is approved and merged, check out `main` and pull the latest changes.
+2. Tag the release:
+   ```sh
+   git tag -am "Version x.y.z" x.y.z
    ```
-   $ git tag -am "Version x.y.z" x.y.z
+3. Push the tag
+   ```sh
+   git push origin x.y.z
    ```
-6. Push
+
+The tag will trigger a GitHub Action workflow which will upload the artifacts to Maven Central and create a GitHub release.
+
+### JetBrains Marketplace Approval
+Releases of the IntelliJ IDEA plugin are subject to JetBrains' manual approval for every version. While the official documentation states that approval may take **2–3 business days**, in practice, the plugin may appear on the JetBrains Marketplace within approximately **3 hours**.
+
+## 3. Prepare for the Next Development Cycle
+
+1. Once the publish is done, update version number `gradle.properties` to next snapshot version (`x.y.z-SNAPSHOT`).
+2. Commit:
+   ```sh
+   $ git commit -am "chore: prepare next development version."
    ```
-   $ git push && git push --tags
-   ```
-The tag will trigger a GitHub Action workflow which will upload the artifacts to Maven Central and create a GitHub release
+3. Push the branch and create a pull request.
 
 
-7. Once publish is done, update version number `gradle.properties` to next snapshot version (x.y.z-SNAPSHOT)
-8. Commit and push
+## 3. Prepare for the Next Development Cycle
+
+1. Once the publish is done, update version number `gradle.properties` to next snapshot version (`x.y.z-SNAPSHOT`).
+2. Commit:
+   ```sh
+   $ git commit -am "chore: prepare next development version."
    ```
-   $ git commit -am "chore: prepare next development version." && git push
-   ```
+3. Push the branch and create a pull request.


### PR DESCRIPTION
The previous release note was written based on the assumption that changes are pushed directly to the `main` branch. This PR updates it to follow a branching workflow.





