### PR TITLE
chore: Add temporary log for space usage

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Log Gradle cache size before Gradle tasks
+        run: df -h
+
+      - name: Log Gradle cache size before build
+        run: du -sh ~/.gradle/caches || true
+
       - name: Execute buildHealth for build-logic
         run: './gradlew -p build-logic buildHealth -s'
 
@@ -49,3 +55,15 @@ jobs:
 
       - name: Execute buildHealth for main project
         run: './gradlew buildHealth -s'
+
+      - name: Log disk space after Gradle tasks
+        if: always()
+        run: df -h
+
+      - name: Log Gradle cache size after build
+        if: always()
+        run: du -sh ~/.gradle/caches || true
+
+      - name: Log final disk usage (top 20 largest directories)
+        if: always()
+        run: du -h | sort -hr | head -n 20

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Log Gradle cache size before Gradle tasks
+        run: df -h
+
+      - name: Log Gradle cache size before build
+        run: du -sh ~/.gradle/caches || true
+
       - name: Execute buildHealth for build-logic
         run: './gradlew -p build-logic buildHealth -s'
 
@@ -53,3 +59,15 @@ jobs:
 
       - name: Execute buildHealth for main project
         run: './gradlew buildHealth -s'
+
+      - name: Log disk space after Gradle tasks
+        if: always()
+        run: df -h
+
+      - name: Log Gradle cache size after build
+        if: always()
+        run: du -sh ~/.gradle/caches || true
+
+      - name: Log final disk usage (top 20 largest directories)
+        if: always()
+        run: du -h | sort -hr | head -n 20


### PR DESCRIPTION
## 📝 Description
We keep getting `System.IO.IOException: No space left on device : '/home/runner/runners/2.322.0/_diag/Worker_20250226-220727-utc.log'` on main ([example build](https://github.com/block/kotlin-formatter/actions/runs/13551556399/job/37885093582))

This PR adds logs to understand what uses the disk space. The change will be reverted later once the issue is resolved.