### PR TITLE
fix: Remove Gradle cache to free up space for Github Workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,3 +67,15 @@ jobs:
       - name: Log final disk usage (top 20 largest directories)
         if: always()
         run: du -h | sort -hr | head -n 20
+
+      - name: Clean up Gradle caches
+        if: always()
+        run: rm -rf ~/.gradle/caches
+
+      - name: Log disk space after cleaning up Gradle caches
+        if: always()
+        run: df -h
+
+      - name: Log Gradle cache size after cleaning up Gradle caches
+        if: always()
+        run: du -sh ~/.gradle/caches || true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -71,3 +71,15 @@ jobs:
       - name: Log final disk usage (top 20 largest directories)
         if: always()
         run: du -h | sort -hr | head -n 20
+
+      - name: Clean up Gradle caches
+        if: always()
+        run: rm -rf ~/.gradle/caches
+
+      - name: Log disk space after cleaning up Gradle caches
+        if: always()
+        run: df -h
+
+      - name: Log Gradle cache size after cleaning up Gradle caches
+        if: always()
+        run: du -sh ~/.gradle/caches || true


### PR DESCRIPTION
## 📝 Description
We found that Gradle stores [45GB of cache in the ~/.gradle/caches directory](https://github.com/block/kotlin-formatter/actions/runs/13554981642/job/37887198113#step:13:15) which caused `System.IO.IOException: No space left on device : '/home/runner/runners/2.322.0/_diag/Worker_20250226-225442-utc.log'` failure ([build](https://github.com/block/kotlin-formatter/actions/runs/13554981642/job/37887198113#step:13:15))


I will remove all the logging after we are confident that the issue is fixed