### PR TITLE
chore: Clean up debugging logs from workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,12 +41,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Log Gradle cache size before Gradle tasks
-        run: df -h
-
-      - name: Log Gradle cache size before build
-        run: du -sh ~/.gradle/caches || true
-
       - name: Execute buildHealth for build-logic
         run: './gradlew -p build-logic buildHealth -s'
 
@@ -56,26 +50,19 @@ jobs:
       - name: Execute buildHealth for main project
         run: './gradlew buildHealth -s'
 
-      - name: Log disk space after Gradle tasks
-        if: always()
-        run: df -h
-
-      - name: Log Gradle cache size after build
-        if: always()
-        run: du -sh ~/.gradle/caches || true
-
-      - name: Log final disk usage (top 20 largest directories)
-        if: always()
-        run: du -h | sort -hr | head -n 20
-
+      # Gradle caches can exceed 45GB, potentially causing "No space left on device" errors.
+      # Clean up caches to free disk space.
       - name: Clean up Gradle caches
         if: always()
-        run: rm -rf ~/.gradle/caches
-
-      - name: Log disk space after cleaning up Gradle caches
-        if: always()
-        run: df -h
-
-      - name: Log Gradle cache size after cleaning up Gradle caches
-        if: always()
-        run: du -sh ~/.gradle/caches || true
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          
+          echo "Gradle cache size before cleanup:"
+          du -sh ~/.gradle/caches || true
+          
+          echo "Cleaning up Gradle caches..."
+          rm -rf ~/.gradle/caches
+          
+          echo "Disk space after cleanup:"
+          df -h

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,3 +108,20 @@ jobs:
           ./gradlew idea-plugin:publishPlugin
         env:
           JETBRAINS_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_SQUARE_PLUGINS }}
+
+      # Gradle caches can exceed 45GB, potentially causing "No space left on device" errors.
+      # Clean up caches to free disk space.
+      - name: Clean up Gradle caches
+        if: always()
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          
+          echo "Gradle cache size before cleanup:"
+          du -sh ~/.gradle/caches || true
+          
+          echo "Cleaning up Gradle caches..."
+          rm -rf ~/.gradle/caches
+          
+          echo "Disk space after cleanup:"
+          df -h

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -60,26 +60,19 @@ jobs:
       - name: Execute buildHealth for main project
         run: './gradlew buildHealth -s'
 
-      - name: Log disk space after Gradle tasks
-        if: always()
-        run: df -h
-
-      - name: Log Gradle cache size after build
-        if: always()
-        run: du -sh ~/.gradle/caches || true
-
-      - name: Log final disk usage (top 20 largest directories)
-        if: always()
-        run: du -h | sort -hr | head -n 20
-
+      # Gradle caches can exceed 45GB, potentially causing "No space left on device" errors.
+      # Clean up caches to free disk space.
       - name: Clean up Gradle caches
         if: always()
-        run: rm -rf ~/.gradle/caches
-
-      - name: Log disk space after cleaning up Gradle caches
-        if: always()
-        run: df -h
-
-      - name: Log Gradle cache size after cleaning up Gradle caches
-        if: always()
-        run: du -sh ~/.gradle/caches || true
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          
+          echo "Gradle cache size before cleanup:"
+          du -sh ~/.gradle/caches || true
+          
+          echo "Cleaning up Gradle caches..."
+          rm -rf ~/.gradle/caches
+          
+          echo "Disk space after cleanup:"
+          df -h


### PR DESCRIPTION
## 📝 Description
We added logs to debug what caused "No space left on device" errors https://github.com/block/kotlin-formatter/pull/57, which has been fixed by clearing Gradle cache https://github.com/block/kotlin-formatter/pull/58. This PR cleans up all these debugging logs and also clearing Gradle cache in publish pipeline


