### PR TITLE
Add daemon mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The CLI provides the following capabilities:
 - **Integrate with Git workflows**:
   - **Pre-commit**: Format staged files before committing.
   - **Pre-push**: Check committed files before pushing.
+- **Daemon mode (experimental)**: Run a background process to avoid JVM startup time on repeated formatting calls.
 
 ### Usage
 ```bash
@@ -41,6 +42,8 @@ kotlin-format [OPTIONS] [FILES...]
 | `--pre-push`            | Check committed files as part of the pre-push process. *Mutually exclusive with `--pre-commit`.* |
 | `--push-commit=<text>`  | The SHA of the commit to use for pre-push. Defaults to `HEAD`.                            |
 | `--print-stats`         | Emit performance-related statistics to help diagnose performance issues.                 |
+| `--daemon`              | Run the CLI in daemon mode.                                                               |
+| `--stop-daemon`         | Stop the daemon if it's running.                                                          |
 | `-h, --help`            | Show help message and exit.                                                          |
 
 #### Arguments
@@ -48,6 +51,47 @@ kotlin-format [OPTIONS] [FILES...]
 | Argument      | Description                                |
 |---------------|--------------------------------------------|
 | `<files>`     | Files or directories to format. Use `-` for standard input. |
+
+### ⚡ Daemon Mode (Experimental)
+⚠️ _Warning: daemon mode is experimental and subject to change_ ⚠️
+Formatting via the CLI involves slow Java startup. To avoid this, Kotlin Formatter can be run in daemon mode.
+```bash
+kotlin-format --daemon
+```
+
+In daemon mode, the CLI starts a server that listens for requests to format files. The port is chosen dynamically, and written to .kotlinformatter/kf.lock in the root of the git dir where kotlin-format is run.
+Only one daemon will run per git dir. If a daemon is already running, invoking `kotlin-format --daemon` will be a no-op, unless the running daemon is an older version.
+
+.kotlinformatter/kf.lock should be added to your .gitignore.
+
+The daemon only supports a limited set of formatting options compared to the CLI. To format files using the daemon, send a message containing the options:
+```bash
+pre-commit <files>
+pre-push <sha> <files>
+```
+
+The daemon will respond with a status code on the first line of the response, followed by the output of the formatting operation.
+
+A full example of using the daemon might look like this:
+```bash
+# start the daemon in the background
+nohup kotlin-format --daemon > /dev/null 2>&1 &
+# read values from lockfile
+line=$(head -n 1 "$daemon_lock_file")
+version=$(echo "$line" | cut -d ' ' -f 1)
+port=$(echo "$line" | cut -d ' ' -f 2)
+# format files
+echo pre-commit file1.kt file2.kt | nc localhost $port
+```
+
+Additionally, the daemon knows the following commands:
+```bash
+exit # stop the daemon
+status # get the status of the daemon
+```
+
+The daemon will automatically shut down after one hour of inactivity, or if it's been running for more than 24 hours.
+You can also manually shut down the daemon by sending the `exit` command, or running `kotlin-format --stop-daemon`.
 
 ### Installing the CLI
 
@@ -105,44 +149,3 @@ Make sure "Optimize imports" is NOT enabled for the "Kotlin" file type.
 
 ### IntelliJ IDEA Plugin Installation
 [Download from JetBrains Marketplace](https://plugins.jetbrains.com/plugin/26482-kotlin-formatter)
-
-## Daemon Mode
-⚠️ _Warning: daemon mode is experimental and subject to change_ ⚠️
-Formatting via the CLI involves slow Java startup. To avoid this, Kotlin Formatter can be run in daemon mode.
-```bash
-kotlin-format --daemon
-```
-
-In daemon mode, the CLI starts a server that listens for requests to format files. The port is chosen dynamically, and written to .kotlinformatter/kf.lock in the root of the git dir where kotlin-format is run.
-Only one daemon will run per git dir. If a daemon is already running, invoking `kotlin-format --daemon` will be a no-op, unless the running daemon is an older version.
-
-.kotlinformatter/kf.lock should be added to your .gitignore.
-
-The daemon only supports a limited set of formatting options compared to the CLI. To format files using the daemon, send a message containing the options:
-```bash
-pre-commit <files>
-pre-push <sha> <files>
-```
-
-The daemon will respond with a status code on the first line of the response, followed by the output of the formatting operation.
-
-A full example of using the daemon might look like this:
-```bash
-# start the daemon in the background
-nohup kotlin-format --daemon > /dev/null 2>&1 &
-# read values from lockfile
-line=$(head -n 1 "$daemon_lock_file")
-version=$(echo "$line" | cut -d ' ' -f 1)
-port=$(echo "$line" | cut -d ' ' -f 2)
-# format files
-echo pre-commit file1.kt file2.kt | nc localhost $port
-```
-
-Additionally, the daemon knows the following commands:
-```bash
-exit # stop the daemon
-status # get the status of the daemon
-```
-
-The daemon will automatically shut down after one hour of inactivity, or if it's been running for more than 24 hours.
-You can also manually shut down the daemon by sending the `exit` command, or running `kotlin-format --stop-daemon`.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ junitEngine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref =
 junitLauncher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatform" }
 junitParams = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junitJupiter" }
 kotlinStdLib = { module = "org.jetbrains.kotlin:kotlin-stdlib" }
+kotlinxCoroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.10.1" }
 ktfmt = { module = "com.facebook:ktfmt", version.ref = "ktfmt" }
 mordantCore = { module = "com.github.ajalt.mordant:mordant-core", version.ref = "mordant" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,6 @@ junitEngine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref =
 junitLauncher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatform" }
 junitParams = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junitJupiter" }
 kotlinStdLib = { module = "org.jetbrains.kotlin:kotlin-stdlib" }
-kotlinxCoroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.10.1" }
 ktfmt = { module = "com.facebook:ktfmt", version.ref = "ktfmt" }
 mordantCore = { module = "com.github.ajalt.mordant:mordant-core", version.ref = "mordant" }
 

--- a/kotlin-format/build.gradle.kts
+++ b/kotlin-format/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
   implementation(libs.clikt)
   implementation(libs.cliktCore)
   implementation(libs.ktfmt)
-  implementation(libs.kotlinxCoroutinesCore)
 
   testImplementation(libs.junitApi)
   testImplementation(libs.assertj)

--- a/kotlin-format/build.gradle.kts
+++ b/kotlin-format/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   implementation(libs.clikt)
   implementation(libs.cliktCore)
   implementation(libs.ktfmt)
+  implementation(libs.kotlinxCoroutinesCore)
 
   testImplementation(libs.junitApi)
   testImplementation(libs.assertj)
@@ -44,7 +45,7 @@ tasks.withType<JavaCompile> {
 }
 
 application {
-  mainClass.set("xyz.block.kotlinformatter.KotlinFormatterKt")
+  mainClass.set("xyz.block.kotlinformatter.CliKt")
 }
 
 group = providers.gradleProperty("group").get()

--- a/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/Cli.kt
+++ b/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/Cli.kt
@@ -1,0 +1,117 @@
+package xyz.block.kotlinformatter
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.PrintHelpMessage
+import com.github.ajalt.clikt.core.PrintMessage
+import com.github.ajalt.clikt.core.ProgramResult
+import com.github.ajalt.clikt.core.main
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.multiple
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import java.io.InputStream
+
+/**
+ * Command-line interface to format Kotlin source code files.
+ *
+ * ## Usage:
+ * ```
+ * - kotlin-format [OPTIONS] <File1.kt> <File2.kt> ...
+ * - kotlin-format --help
+ * ```
+ */
+class Cli(private val inputStream: InputStream = System.`in`) : CliktCommand(name = "kotlin-format") {
+  private val files: List<String> by argument(help = HELP_FILES).multiple()
+  private val setExitIfChanged: Boolean by
+  option("--set-exit-if-changed", help = HELP_SET_EXIT_IF_CHANGED).flag(default = false)
+  private val dryRun: Boolean by option("--dry-run", help = HELP_DRY_RUN).flag(default = false)
+  private val preCommit: Boolean by option("--pre-commit", help = HELP_PRE_COMMIT).flag(default = false)
+  private val prePush: Boolean by option("--pre-push", help = HELP_PRE_PUSH).flag(default = false)
+  private val pushCommit: String by option("--push-commit", help = HELP_PUSH_COMMIT).default("HEAD")
+  private val stats: Boolean by
+  option("--print-stats", help = HELP_PRINT_STATS, envvar = "KOTLIN_FORMATTER_STATS").flag(default = false)
+  private val daemon: Boolean by option("--daemon", help = "Start the Kotlin formatter daemon.").flag(default = false)
+  private val stopDaemon: Boolean by option("--stop-daemon", help = "Stop the Kotlin formatter daemon.").flag(default = false)
+
+  override fun help(context: Context) = HELP_MESSAGE
+
+  override fun run() {
+    if (daemon) {
+      Daemon().start()
+      return
+    }
+
+    if (stopDaemon) {
+      Daemon().stop()
+      return
+    }
+
+    // Validate inputs
+    if (files.isEmpty()) {
+      throw PrintHelpMessage(this.currentContext)
+    }
+    if (preCommit && prePush) {
+      // These two options are mutually exclusive
+      throw PrintMessage("--pre-push and --pre-commit are mutually exclusive", ExitCode.BAD_ARGS, true)
+    }
+    if (prePush && !dryRun) {
+      throw PrintMessage("--pre-push without --dry-run is currently unsupported", ExitCode.BAD_ARGS, true)
+    }
+
+    val stdStreamsMode = files.size == 1 && files.contains("-")
+
+    val formatter = KotlinFormatter(
+      inputStream = inputStream,
+      files = files,
+      dryRun = dryRun,
+      preCommit = preCommit,
+      prePush = prePush,
+      pushCommit = pushCommit,
+      stats = stats,
+      outputCallback = { echo(it, trailingNewline = false) }
+    )
+
+    val result = formatter.format()
+
+    // Do not output anything apart from formatted code when in stdStreamsMode
+    if (!stdStreamsMode || dryRun) {
+      echo(result.output, trailingNewline = false)
+
+      result.stats?.let { stats ->
+        echo("Time to configure: ${stats.configurationTimeMs}ms", err = true)
+        echo("   Time to format: ${stats.formattingTimeMs}ms", err = true)
+        echo("   Time to report: ${stats.reportingTimeMs}ms", err = true)
+        echo("Formattable count: ${stats.formattableCount}", err = true)
+        echo("       Blob count: ${stats.blobCount}", err = true)
+        echo("       File count: ${stats.fileCount}", err = true)
+        echo("  Chars processed: ${stats.charsProcessed}", err = true)
+      }
+    }
+
+    if (result.hasFailure) {
+      throw ProgramResult(ExitCode.FAILURE)
+    }
+
+    if (setExitIfChanged && result.hasFileChanged) {
+      throw ProgramResult(ExitCode.FILE_CHANGED)
+    }
+  }
+
+  companion object {
+    const val HELP_MESSAGE = "Command-line interface to format Kotlin source code files."
+    const val HELP_FILES = "Files or directory to format."
+    const val HELP_SET_EXIT_IF_CHANGED =
+      "Set the program to exit with a non-zero exit code if any files needed to be changed."
+    const val HELP_DRY_RUN = "Displays the changes that would be made but does not write the changes to disk."
+    const val HELP_PRE_COMMIT =
+      "Format staged files as part of the pre-commit process. Mutually exclusive with --pre-push."
+    const val HELP_PRE_PUSH =
+      "Check committed files as part of the pre-push process. Mutually exclusive with --pre-commit."
+    const val HELP_PUSH_COMMIT = "The SHA of the commit to use for pre-push. Defaults to 'HEAD'."
+    const val HELP_PRINT_STATS = "Emit performance-related statistics to help diagnose performance issues."
+  }
+}
+
+fun main(args: Array<String>) = Cli().main(args)

--- a/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/Daemon.kt
+++ b/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/Daemon.kt
@@ -1,0 +1,248 @@
+package xyz.block.kotlinformatter
+
+import java.io.RandomAccessFile
+import java.net.ServerSocket
+import java.net.Socket
+import java.nio.channels.FileLock
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.Duration
+import java.time.Instant
+import kotlin.io.path.deleteExisting
+import kotlin.concurrent.thread
+
+class Daemon(
+  private val systemExiter: SystemExiter = RealSystemExiter(),
+  private val idleTimeout: Duration = Duration.ofHours(1),
+  private val maxRuntime: Duration = Duration.ofDays(1),
+  private val timeoutCheckerInterval: Duration = Duration.ofMinutes(1),
+  private val workingDir: Path = rootGitPath,
+  private val version: Int = DAEMON_VERSION
+) {
+  private var lockFile: RandomAccessFile? = null
+  private var lock: FileLock? = null
+  private var lastCommandTime: Instant = Instant.now()
+  private val startTime: Instant = Instant.now()
+  private var timeoutChecker: Thread? = null
+  private var serverSocket: ServerSocket? = null
+  private var isRunning = false
+  private val lockFilePath = workingDir.resolve(LOCK_FILE_PATH)
+
+  fun isRunning(): Boolean = isRunning
+
+  private fun shouldShutdown(): Boolean {
+    val now = Instant.now()
+    val idleTime = Duration.between(lastCommandTime, now)
+    val totalRuntime = Duration.between(startTime, now)
+
+    if (idleTime >= idleTimeout) {
+      println("Shutting down due to inactivity (${idleTime.seconds}s idle)")
+      return true
+    }
+
+    if (totalRuntime >= maxRuntime) {
+      println("Shutting down due to maximum runtime exceeded (${totalRuntime.seconds}s)")
+      return true
+    }
+
+    return false
+  }
+
+  private fun startTimeoutChecker() {
+    timeoutChecker = thread(start = true) {
+      while (!Thread.currentThread().isInterrupted) {
+        if (shouldShutdown()) {
+          serverSocket?.close()
+          cleanup()
+          systemExiter.exit(0)
+        }
+        Thread.sleep(timeoutCheckerInterval.seconds)
+      }
+    }
+  }
+
+  fun start() {
+    try {
+      // Change working directory so git commands work as expected
+      workingDir.let { System.setProperty("user.dir", it.toString()) }
+
+      lockFilePath.parent.toFile().mkdirs()
+
+      // If there's a running daemon with an older version, stop it first
+      val existingDaemonData = readLockFile()
+      if (existingDaemonData != null && existingDaemonData.version < version) {
+        stop()
+        Thread.sleep(100) // Wait for the old daemon to stop
+      }
+
+      // Attempt to lock the file to ensure only one instance is running
+      lockFile = RandomAccessFile(lockFilePath.toFile().path, "rw")
+      lock = lockFile?.channel?.tryLock()
+
+      if (lock == null) {
+        println("Daemon is already running")
+        cleanup()
+        return
+      }
+
+      // Add shutdown hook to ensure cleanup on unexpected termination
+      Runtime.getRuntime().addShutdownHook(Thread { cleanup() })
+
+      serverSocket = ServerSocket(0)
+      val assignedPort = serverSocket!!.localPort
+      
+      // Start the timeout checker thread
+      startTimeoutChecker()
+      
+      // Clear and write the lock file atomically
+      lockFile?.let { file ->
+        file.setLength(0)
+        file.seek(0)
+        writeLockFile(DaemonData(DAEMON_VERSION, assignedPort))
+      }
+
+      isRunning = true
+
+      while (true) {
+        try {
+          val clientSocket: Socket = serverSocket!!.accept()
+          // Update last command time when a connection is received
+          lastCommandTime = Instant.now()
+
+          clientSocket.getInputStream().bufferedReader().use { reader ->
+            val message = reader.readLine()
+            if (message != null) {
+              val messageParts = message.split(" ")
+              val command = messageParts[0]
+
+              when (command) {
+                "exit" -> {
+                  clientSocket.close()
+                  serverSocket?.close()
+                  cleanup()
+                  systemExiter.exit(0)
+                }
+
+                "status" -> {
+                  val idleTime = Duration.between(lastCommandTime, Instant.now())
+                  val totalRuntime = Duration.between(startTime, Instant.now())
+                  val response = "Daemon Status:\n" +
+                      "Idle time: ${idleTime.seconds}s\n" +
+                      "Total runtime: ${totalRuntime.seconds}s\n" +
+                      "Time until idle timeout: ${idleTimeout.seconds - idleTime.seconds}s\n" +
+                      "Time until max runtime timeout: ${maxRuntime.seconds - totalRuntime.seconds}s"
+                  clientSocket.write(ExitCode.SUCCESS, response)
+                }
+
+                "pre-commit" -> {
+                  val files = messageParts.drop(1)
+                  val result = KotlinFormatter(files = files, preCommit = true).format()
+                  val exitCode = if (result.hasFailure) ExitCode.FAILURE else ExitCode.SUCCESS
+                  clientSocket.write(exitCode, result.output)
+                }
+
+                "pre-push" -> {
+                  val pushCommit = messageParts[1]
+                  val files = messageParts.drop(2)
+                  val result =
+                    KotlinFormatter(files = files, prePush = true, pushCommit = pushCommit, dryRun = true).format()
+                  val exitCode = when {
+                    result.hasFailure -> ExitCode.FAILURE
+                    result.hasFileChanged -> ExitCode.FILE_CHANGED
+                    else -> ExitCode.SUCCESS
+                  }
+                  clientSocket.write(exitCode, result.output)
+                }
+
+                else -> {
+                  clientSocket.write(ExitCode.FAILURE, "Unknown command: $command")
+                }
+              }
+            }
+          }
+
+          clientSocket.close()
+        } catch (e: Exception) {
+          if (!serverSocket?.isClosed!!) {
+            println("Error handling client connection: ${e.message}")
+            e.printStackTrace()
+          }
+          // If the socket is closed (due to timeout), break the loop
+          if (serverSocket?.isClosed == true) {
+            break
+          }
+        }
+      }
+    } catch (e: Exception) {
+      println("Error in daemon: ${e.message}")
+      cleanup()
+      throw e
+    }
+  }
+
+  private fun cleanup() {
+    try {
+      timeoutChecker?.interrupt()
+      lock?.release()
+      lockFile?.close()
+      serverSocket?.close()
+      if (lockFilePath.toFile().exists()) {
+        lockFilePath.deleteExisting()
+      }
+    } catch (e: Exception) {
+      println("Error during cleanup: ${e.message}")
+    } finally {
+      lock = null
+      lockFile = null
+      timeoutChecker = null
+      serverSocket = null
+      isRunning = false
+    }
+  }
+
+  fun stop() {
+    val daemonData = readLockFile()
+    if (daemonData == null) {
+      println("Daemon is not running")
+      return
+    }
+
+    try {
+      Socket("localhost", daemonData.port).use { socket ->
+        socket.getOutputStream().write("exit\n".toByteArray())
+      }
+    } catch (e: Exception) {
+      println("Error stopping daemon: ${e.message}")
+      // If we can't connect to the daemon, it might have crashed
+      // Try to clean up the lock file
+      if (lockFilePath.toFile().exists()) {
+        lockFilePath.deleteExisting()
+      }
+    }
+  }
+
+  private fun writeLockFile(daemonData: DaemonData) {
+    lockFile?.writeBytes("${daemonData.version} ${daemonData.port}")
+  }
+
+  fun readLockFile(): DaemonData? {
+    if (!lockFilePath.toFile().exists()) return null
+    return try {
+      val parts = lockFilePath.toFile().readText().split(" ")
+      DaemonData(parts[0].toInt(), parts[1].toInt())
+    } catch (e: Exception) {
+      println("Error reading lock file: ${e.message}")
+      null
+    }
+  }
+
+  private fun Socket.write(exitCode: Int, message: String) {
+    getOutputStream().write("${exitCode}\n$message".toByteArray())
+  }
+
+  companion object {
+    const val DAEMON_VERSION = 1
+    val LOCK_FILE_PATH = Paths.get(".kotlinformatter/kf.lock")
+    val rootGitPath by lazy { Paths.get(GitProcessRunner.run("rev-parse", "--show-toplevel").trim()) }
+  }
+}

--- a/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/DaemonData.kt
+++ b/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/DaemonData.kt
@@ -1,0 +1,6 @@
+package xyz.block.kotlinformatter
+
+data class DaemonData(
+  val version: Int,
+  val port: Int,
+)

--- a/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/ExitCode.kt
+++ b/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/ExitCode.kt
@@ -1,0 +1,8 @@
+package xyz.block.kotlinformatter
+
+object ExitCode {
+  const val SUCCESS = 0
+  const val FAILURE = 1
+  const val BAD_ARGS = 2
+  const val FILE_CHANGED = 3
+}

--- a/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/FormattingCommandResult.kt
+++ b/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/FormattingCommandResult.kt
@@ -1,0 +1,8 @@
+package xyz.block.kotlinformatter
+
+data class FormattingCommandResult(
+  val output: String,
+  val hasFailure: Boolean,
+  val hasFileChanged: Boolean,
+  val stats: FormattingStats? = null
+)

--- a/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/FormattingStats.kt
+++ b/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/FormattingStats.kt
@@ -1,0 +1,11 @@
+package xyz.block.kotlinformatter
+
+data class FormattingStats(
+  val configurationTimeMs: Float,
+  val formattingTimeMs: Float,
+  val reportingTimeMs: Float,
+  val formattableCount: Int,
+  val blobCount: Int,
+  val fileCount: Int,
+  val charsProcessed: Long
+)

--- a/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/KotlinFormatter.kt
+++ b/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/KotlinFormatter.kt
@@ -15,63 +15,34 @@
  */
 package xyz.block.kotlinformatter
 
-import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.core.Context
-import com.github.ajalt.clikt.core.PrintHelpMessage
-import com.github.ajalt.clikt.core.PrintMessage
-import com.github.ajalt.clikt.core.ProgramResult
-import com.github.ajalt.clikt.core.main
-import com.github.ajalt.clikt.parameters.arguments.argument
-import com.github.ajalt.clikt.parameters.arguments.multiple
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.option
-import xyz.block.kotlinformatter.TriggerFormatter.Companion.FormattingResult
 import java.io.InputStream
 import java.time.Duration
 import java.time.Instant
 import java.util.stream.Stream
+import kotlin.streams.toList
+import xyz.block.kotlinformatter.TriggerFormatter.Companion.FormattingResult
 
-private const val EXIT_CODE_FAILURE = 1
-private const val EXIT_CODE_BAD_ARGS = 2
-private const val EXIT_CODE_FILE_CHANGED = 3
 
-fun main(args: Array<String>) = KotlinFormatter().main(args)
 
-/**
- * Command-line interface to format Kotlin source code files.
- *
- * ## Usage:
- * ```
- * - kotlin-format [OPTIONS] <File1.kt> <File2.kt> ...
- * - kotlin-format --help
- * ```
- */
-class KotlinFormatter(private val inputStream: InputStream = System.`in`) :
-  CliktCommand(name = "kotlin-format") {
-  private val files: List<String> by argument(help = HELP_FILES).multiple()
-  private val setExitIfChanged: Boolean by
-    option("--set-exit-if-changed", help = HELP_SET_EXIT_IF_CHANGED).flag(default = false)
-  private val dryRun: Boolean by option("--dry-run", help = HELP_DRY_RUN).flag(default = false)
-  private val preCommit: Boolean by option("--pre-commit", help = HELP_PRE_COMMIT).flag(default = false)
-  private val prePush: Boolean by option("--pre-push", help = HELP_PRE_PUSH).flag(default = false)
-  private val pushCommit: String by option("--push-commit", help = HELP_PUSH_COMMIT).default("HEAD")
-  private val stats: Boolean by
-    option("--print-stats", help = HELP_PRINT_STATS, envvar = "KOTLIN_FORMATTER_STATS").flag(default = false)
+class KotlinFormatter(
+  private val files: List<String>,
+  private val dryRun: Boolean = false,
+  private val preCommit: Boolean = false,
+  private val prePush: Boolean = false,
+  private val pushCommit: String = "HEAD",
+  private val stats: Boolean = false,
+  private val inputStream: InputStream = System.`in`,
+  private val outputCallback: (String) -> Unit = { println(it) }
+) {
 
-  override fun help(context: Context) = HELP_MESSAGE
-
-  override fun run() {
+  fun format(): FormattingCommandResult {
     // 1. Validate inputs
     if (files.isEmpty()) {
-      throw PrintHelpMessage(this.currentContext)
+      throw IllegalArgumentException("No files to format")
     }
+
     if (preCommit && prePush) {
-      // These two options are mutually exclusive
-      throw PrintMessage("--pre-push and --pre-commit are mutually exclusive", EXIT_CODE_BAD_ARGS, true)
-    }
-    if (prePush && !dryRun) {
-      throw PrintMessage("--pre-push without --dry-run is currently unsupported", EXIT_CODE_BAD_ARGS, true)
+      throw IllegalArgumentException("--pre-push and --pre-commit are mutually exclusive")
     }
 
     val timeStart = Instant.now()
@@ -80,7 +51,7 @@ class KotlinFormatter(private val inputStream: InputStream = System.`in`) :
     // 2. Create configs from args
     val formattingConfigs =
       if (stdStreamsMode) {
-        FormattingConfigs.forStdStreams(inputStream) { echo(it, trailingNewline = false) }
+        FormattingConfigs.forStdStreams(inputStream, outputCallback)
       } else if (preCommit) {
         FormattingConfigs.forPreCommit(files, dryRun)
       } else if (prePush) {
@@ -102,7 +73,7 @@ class KotlinFormatter(private val inputStream: InputStream = System.`in`) :
 
     val timeFormatted = Instant.now()
 
-    // Making a single string and outputting it once is much faster than calling echo for each
+    // Making a single string and outputting it once is much faster than calling outputCallback for each
     // result individually
     val output = StringBuilder()
 
@@ -139,51 +110,28 @@ class KotlinFormatter(private val inputStream: InputStream = System.`in`) :
       )
     }
 
-    // Do not output anything apart from formatted code when in stdStreamsMode
-    if (!stdStreamsMode || dryRun) {
-      echo(output, trailingNewline = false)
+    val timeEnd = Instant.now()
 
-      val timeEnd = Instant.now()
-      if (stats) {
-        echo("Time to configure: ${Duration.between(timeStart, timeConfigged).toNanos() / 1.0e6f}ms", err = true)
-        echo("   Time to format: ${Duration.between(timeConfigged, timeFormatted).toNanos() / 1.0e6f}ms", err = true)
-        echo("   Time to report: ${Duration.between(timeFormatted, timeEnd).toNanos() / 1.0e6f}ms", err = true)
-        echo("Formattable count: ${formattingConfigs.formattables.size}", err = true)
-        echo(
-          "       Blob count: ${formattingConfigs.formattables.filterIsInstance<FormattableBlob>().size}",
-          err = true,
-        )
-        echo(
-          "       File count: ${formattingConfigs.formattables.filterIsInstance<FormattableFile>().size}",
-          err = true,
-        )
-        echo("  Chars processed: ${formatter.charsProcessed()}", err = true)
-      }
-    }
+    val formattingStats = if (stats) {
+      FormattingStats(
+        configurationTimeMs = Duration.between(timeStart, timeConfigged).toNanos() / 1.0e6f,
+        formattingTimeMs = Duration.between(timeConfigged, timeFormatted).toNanos() / 1.0e6f,
+        reportingTimeMs = Duration.between(timeFormatted, timeEnd).toNanos() / 1.0e6f,
+        formattableCount = formattingConfigs.formattables.size,
+        blobCount = formattingConfigs.formattables.filterIsInstance<FormattableBlob>().size,
+        fileCount = formattingConfigs.formattables.filterIsInstance<FormattableFile>().size,
+        charsProcessed = formatter.charsProcessed()
+      )
+    } else null
 
-    if (hasFailure) {
-      throw ProgramResult(EXIT_CODE_FAILURE)
-    }
-
-    if (setExitIfChanged && hasFileChanged) {
-      throw ProgramResult(EXIT_CODE_FILE_CHANGED)
-    }
+    return FormattingCommandResult(
+      output = output.toString(),
+      hasFailure = hasFailure,
+      hasFileChanged = hasFileChanged,
+      stats = formattingStats
+    )
   }
 
   // Stream doesn't have a toSortedSet() method, so we need to convert it to a list first.
   private fun <E : Comparable<E>> Stream<E>.toSortedSet() = toList().toSortedSet()
-
-  companion object {
-    const val HELP_MESSAGE = "Command-line interface to format Kotlin source code files."
-    const val HELP_FILES = "Files or directory to format."
-    const val HELP_SET_EXIT_IF_CHANGED =
-      "Set the program to exit with a non-zero exit code if any files needed to be changed."
-    const val HELP_DRY_RUN = "Displays the changes that would be made but does not write the changes to disk."
-    const val HELP_PRE_COMMIT =
-      "Format staged files as part of the pre-commit process. Mutually exclusive with --pre-push."
-    const val HELP_PRE_PUSH =
-      "Check committed files as part of the pre-push process. Mutually exclusive with --pre-commit."
-    const val HELP_PUSH_COMMIT = "The SHA of the commit to use for pre-push. Defaults to 'HEAD'."
-    const val HELP_PRINT_STATS = "Emit performance-related statistics to help diagnose performance issues."
-  }
 }

--- a/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/KotlinFormatter.kt
+++ b/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/KotlinFormatter.kt
@@ -32,7 +32,7 @@ class KotlinFormatter(
   private val pushCommit: String = "HEAD",
   private val stats: Boolean = false,
   private val inputStream: InputStream = System.`in`,
-  private val outputCallback: (String) -> Unit = { println(it) }
+  private val outputCallback: (String) -> Unit = { print(it) }
 ) {
 
   fun format(): FormattingCommandResult {

--- a/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/SystemExiter.kt
+++ b/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/SystemExiter.kt
@@ -1,0 +1,11 @@
+package xyz.block.kotlinformatter
+
+interface SystemExiter {
+  fun exit(status: Int)
+}
+
+class RealSystemExiter : SystemExiter {
+  override fun exit(status: Int) {
+    System.exit(status)
+  }
+}

--- a/kotlin-format/src/test/kotlin/xyz/block/kotlinformatter/CliTest.kt
+++ b/kotlin-format/src/test/kotlin/xyz/block/kotlinformatter/CliTest.kt
@@ -9,12 +9,12 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
-class KotlinFormatterTest {
+class CliTest {
   @Test
   fun `format by kt filenames`(@TempDir tempDir: File) {
     val testDir = TestFixtures.setupTestDirectory(tempDir)
     val result =
-      KotlinFormatter()
+      Cli()
         .test(
           "${testDir.mainExample1} ${testDir.libExample3} ${testDir.libRandomFile} ${testDir.gradleBuildFile} ${testDir.generatedWireSource} non-existing-file.kt"
         )
@@ -44,7 +44,7 @@ class KotlinFormatterTest {
     val testDir = TestFixtures.setupTestDirectory(tempDir)
     val mainSrcDirectory = Paths.get(tempDir.path, "project", "src")
     val libDirectory = Paths.get(tempDir.path, "project", "lib")
-    val result = KotlinFormatter().test("${mainSrcDirectory.toAbsolutePath()} ${libDirectory.toAbsolutePath()}")
+    val result = Cli().test("${mainSrcDirectory.toAbsolutePath()} ${libDirectory.toAbsolutePath()}")
 
     // generatedWireSource, mainAlreadyFormattedFile and libRandomFile should not be part of
     // formatted files
@@ -71,7 +71,7 @@ class KotlinFormatterTest {
   fun `format by kt filenames and directories`(@TempDir tempDir: File) {
     val testDir = TestFixtures.setupTestDirectory(tempDir)
     val libDirectory = Paths.get(tempDir.path, "project", "lib")
-    val result = KotlinFormatter().test("${testDir.mainExample1} ${libDirectory.toAbsolutePath()}")
+    val result = Cli().test("${testDir.mainExample1} ${libDirectory.toAbsolutePath()}")
 
     // generatedWireSource, mainAlreadyFormattedFile, testExample1Test and libRandomFile should not
     // be part of formatted files
@@ -99,7 +99,7 @@ class KotlinFormatterTest {
     val inputContent = TestFixtures.testExample1TestContent
     val inputStream = ByteArrayInputStream(inputContent.toByteArray(Charsets.UTF_8))
 
-    val result = KotlinFormatter(inputStream).test("--set-exit-if-changed -")
+    val result = Cli(inputStream).test("--set-exit-if-changed -")
 
     assertThat(result.stdout).contains(TestFixtures.formattedTestExample1TestContent)
     assertThat(result.statusCode).isEqualTo(3)
@@ -110,7 +110,7 @@ class KotlinFormatterTest {
     val inputContent = TestFixtures.formattedTestExample1TestContent
     val inputStream = ByteArrayInputStream(inputContent.toByteArray(Charsets.UTF_8))
 
-    val result = KotlinFormatter(inputStream).test("--set-exit-if-changed -")
+    val result = Cli(inputStream).test("--set-exit-if-changed -")
 
     assertThat(result.stdout).isEmpty()
     assertThat(result.statusCode).isEqualTo(0)
@@ -119,7 +119,7 @@ class KotlinFormatterTest {
   @Test
   fun `with --dry-run - doesn't format files`(@TempDir tempDir: File) {
     val testDir = TestFixtures.setupTestDirectory(tempDir)
-    val result = KotlinFormatter().test("--dry-run ${testDir.mainExample1}")
+    val result = Cli().test("--dry-run ${testDir.mainExample1}")
 
     assertThat(result.stdout.trimEnd().lines())
       .containsExactlyInAnyOrderElementsOf(listOf("🛠️ Would format ${testDir.mainExample1}"))
@@ -152,7 +152,7 @@ class KotlinFormatterTest {
       testDir.libExample2.writeText(libExample2UpdatedContent)
 
       // 2. Format lib with --pre-commit flag
-      val result = KotlinFormatter().test("--pre-commit lib")
+      val result = Cli().test("--pre-commit lib")
 
       val libExample2Relative = testDir.libExample2.relativeTo(testDir.rootDir).path
       val libExample3Relative = testDir.libExample3.relativeTo(testDir.rootDir).path
@@ -187,7 +187,7 @@ class KotlinFormatterTest {
   @Test
   fun `exits with a non-zero exit code if any files needed to be changed`(@TempDir tempDir: File) {
     val testDir = TestFixtures.setupTestDirectory(tempDir)
-    val result = KotlinFormatter().test("--set-exit-if-changed ${testDir.mainExample1}")
+    val result = Cli().test("--set-exit-if-changed ${testDir.mainExample1}")
 
     assertThat(result.stdout.trimEnd().lines())
       .containsExactlyInAnyOrderElementsOf(listOf("✅ Formatted ${testDir.mainExample1}"))
@@ -209,7 +209,7 @@ class KotlinFormatterTest {
   @Test
   fun `successfully exits if no files to format`(@TempDir tempDir: File) {
     TestFixtures.setupTestDirectory(tempDir)
-    val result = KotlinFormatter().test("non-existing-file.kt")
+    val result = Cli().test("non-existing-file.kt")
 
     assertThat(result.stdout.trimEnd()).isEqualTo("Nothing to format")
     assertThat(result.statusCode).isEqualTo(0)
@@ -218,9 +218,9 @@ class KotlinFormatterTest {
   @Test
   fun `returns help message if no filenames are specified`(@TempDir tempDir: File) {
     TestFixtures.setupTestDirectory(tempDir)
-    val result = KotlinFormatter().test("")
+    val result = Cli().test("")
 
-    assertThat(result.stdout.trimEnd()).contains(KotlinFormatter.HELP_MESSAGE)
+    assertThat(result.stdout.trimEnd()).contains(Cli.HELP_MESSAGE)
     assertThat(result.statusCode).isEqualTo(0)
   }
 
@@ -233,7 +233,7 @@ class KotlinFormatterTest {
       TestUtils.setupGitUser() // needed for commit to work on CI
       GitProcessRunner.run("commit", "-m", "Initial commit")
 
-      val result = KotlinFormatter().test("--pre-push --dry-run --set-exit-if-changed src")
+      val result = Cli().test("--pre-push --dry-run --set-exit-if-changed src")
 
       assertThat(result.statusCode).isNotEqualTo(0)
       assertThat(result.stdout.trimEnd().lines())
@@ -308,7 +308,7 @@ class KotlinFormatterTest {
       GitProcessRunner.run("add", testDir.edgecaseSpaces.path)
 
       // 2. Format lib with --pre-commit flag
-      val result = KotlinFormatter().test("--pre-commit .")
+      val result = Cli().test("--pre-commit .")
 
       val edgecaseSpacesRelative = testDir.edgecaseSpaces.relativeTo(testDir.rootDir).path
       val formattedFiles = listOf(edgecaseSpacesRelative)

--- a/kotlin-format/src/test/kotlin/xyz/block/kotlinformatter/DaemonTest.kt
+++ b/kotlin-format/src/test/kotlin/xyz/block/kotlinformatter/DaemonTest.kt
@@ -214,12 +214,12 @@ class DaemonTest {
         break
       }
 
-      // Only send a status command if we're not close to the max runtime timeout, otherwise we risk
+      // Only send a command if we're not close to the max runtime timeout, otherwise we risk
       // sending the message to a closed socket and causing an exception
       if (Duration.between(startTime, Instant.now()).seconds < MAX_RUNTIME.seconds - IDLE_TIMEOUT.seconds) {
         // Postpone idle timeout so we hit the max runtime timeout instead
         Socket("localhost", daemonData!!.port).use { socket ->
-          socket.getOutputStream().write("status\n".toByteArray())
+          socket.getOutputStream().write("pre-commit foo.kt\n".toByteArray())
           socket.getInputStream().bufferedReader().readText()
         }
       }

--- a/kotlin-format/src/test/kotlin/xyz/block/kotlinformatter/DaemonTest.kt
+++ b/kotlin-format/src/test/kotlin/xyz/block/kotlinformatter/DaemonTest.kt
@@ -1,0 +1,333 @@
+package xyz.block.kotlinformatter
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.net.Socket
+import java.nio.file.Path
+import java.time.Duration
+import java.time.Instant
+import kotlin.concurrent.thread
+
+class TestSystemExiter : SystemExiter {
+  var exitCalled = false
+  var lastExitStatus = -1
+
+  override fun exit(status: Int) {
+    exitCalled = true
+    lastExitStatus = status
+  }
+}
+
+class DaemonTest {
+  private lateinit var daemon: Daemon
+  private lateinit var daemonThread: Thread
+  private lateinit var testExiter: TestSystemExiter
+
+  @TempDir
+  lateinit var tempDir: Path
+
+  @BeforeEach
+  fun setup() {
+    testExiter = TestSystemExiter()
+    daemon = Daemon(
+      systemExiter = testExiter,
+      idleTimeout = IDLE_TIMEOUT,
+      maxRuntime = MAX_RUNTIME,
+      timeoutCheckerInterval = TIMEOUT_CHECKER_INTERVAL,
+      workingDir = tempDir
+    )
+
+    // Start daemon in a separate thread
+    daemonThread = thread(start = true) {
+      try {
+        daemon.start()
+      } catch (e: Exception) {
+        // Ignore exceptions from normal shutdown
+        if (!e.message?.contains("Socket closed")!!) {
+          throw e
+        }
+      }
+    }
+
+    // Wait for daemon to start (max 1 second)
+    var attempts = 0
+    while (!daemon.isRunning() && attempts < 20) {
+      Thread.sleep(50)
+      attempts++
+    }
+
+    assertThat(daemon.isRunning()).isTrue()
+  }
+
+  @AfterEach
+  fun tearDown() {
+    daemon.stop()
+    daemonThread.join(1000) // Wait up to 1 second for thread to finish
+  }
+
+  @Test
+  fun `starts and accepts connections`() {
+    val lockFile = tempDir.resolve(Daemon.LOCK_FILE_PATH).toFile()
+    assertThat(lockFile.exists()).isTrue()
+
+    val daemonData = daemon.readLockFile()
+    assertThat(daemonData).isNotNull
+
+    // Try to connect to the daemon
+    Socket("localhost", daemonData!!.port).use { socket ->
+      socket.getOutputStream().write("status\n".toByteArray())
+      val response = socket.getInputStream().bufferedReader().readText()
+      assertThat(response).contains("Daemon Status")
+      assertThat(response).contains("Time until idle timeout: 2s")
+      assertThat(response).contains("Time until max runtime timeout: 5s")
+    }
+  }
+
+  @Test
+  fun `only one daemon runs at a time`() {
+    // Try to start another daemon
+    val secondTestExiter = TestSystemExiter()
+    val secondDaemon = Daemon(
+      systemExiter = secondTestExiter,
+      workingDir = tempDir
+    )
+    var secondDaemonStarted = false
+
+    thread {
+      try {
+        secondDaemon.start()
+        secondDaemonStarted = true
+      } catch (e: Exception) {
+        // Expected
+      }
+    }
+
+    // Wait a bit and verify the second daemon didn't start
+    Thread.sleep(1000)
+    assertThat(secondDaemonStarted).isFalse()
+  }
+
+  @Test
+  fun `handles pre-commit command`() {
+    val testFile = File(tempDir.toFile(), "Test.kt")
+    testFile.writeText("""
+        fun main() {
+        
+        
+              println("Hello")
+        }
+    """.trimIndent())
+    TestUtils.withWorkingDir(tempDir.toFile()) {
+      GitProcessRunner.run("init")
+      GitProcessRunner.run("add", ".")
+    }
+
+    val daemonData = daemon.readLockFile()
+    assertThat(daemonData).isNotNull
+
+    // Send pre-commit command
+    Socket("localhost", daemonData!!.port).use { socket ->
+      socket.getOutputStream().write("pre-commit ${testFile.absolutePath}\n".toByteArray())
+      val reader = socket.getInputStream().bufferedReader()
+      val exitCode = reader.readLine()
+      assertThat(exitCode).isEqualTo(ExitCode.SUCCESS.toString())
+      val output = reader.readText()
+      assertThat(output).isEqualTo("✅ Formatted Test.kt\n")
+    }
+  }
+
+  @Test
+  fun `handles pre-push command`() {
+    // Create a test Kotlin file
+    val testFile = File(tempDir.toFile(), "Test.kt")
+    testFile.writeText("""
+        fun main() {
+        
+        
+              println("Hello")
+        }
+    """.trimIndent())
+    var pushHash = ""
+    TestUtils.withWorkingDir(tempDir.toFile()) {
+      GitProcessRunner.run("init")
+      GitProcessRunner.run("add", ".")
+      TestUtils.setupGitUser() // needed for commit to work on CI
+      GitProcessRunner.run("commit", "-m", "Initial commit")
+      pushHash =
+        GitProcessRunner.run("log", "-1", "--format=%H").trim()
+    }
+
+    val daemonData = daemon.readLockFile()
+    assertThat(daemonData).isNotNull
+
+    // Send pre-push command
+    Socket("localhost", daemonData!!.port).use { socket ->
+      socket.getOutputStream().write("pre-push $pushHash ${testFile.absolutePath}\n".toByteArray())
+      val reader = socket.getInputStream().bufferedReader()
+      val exitCode = reader.readLine()
+      assertThat(exitCode).isEqualTo(ExitCode.FILE_CHANGED.toString())
+      val output = reader.readText()
+      assertThat(output).isEqualTo(
+        """
+        🛠️ Would format Test.kt
+        ⚠️ The committed files have formatting errors. Please format the files and commit the formatting changes.
+        
+        """.trimIndent())
+    }
+  }
+
+  @Test
+  fun `daemon shuts down after idle timeout`() {
+    var timeoutOccurred = false
+    val startTime = Instant.now()
+
+    while (Duration.between(startTime, Instant.now()).seconds < IDLE_TIMEOUT.seconds + 1) {
+      if (testExiter.exitCalled) {
+        timeoutOccurred = true
+        break
+      }
+      Thread.sleep(100)
+    }
+
+    assertThat(timeoutOccurred).isTrue()
+    assertThat(testExiter.lastExitStatus).isEqualTo(0)
+    // daemon exited because of idle timeout, not max runtime timeout
+    assertThat(Duration.between(startTime, Instant.now()).seconds).isLessThan(MAX_RUNTIME.seconds)
+  }
+
+  @Test
+  fun `daemon shuts down after max runtime timeout`() {
+    val daemonData = daemon.readLockFile()
+    assertThat(daemonData).isNotNull
+
+    var timeoutOccurred = false
+    val startTime = Instant.now()
+
+    while (Duration.between(startTime, Instant.now()).seconds < MAX_RUNTIME.seconds + 1) {
+      if (testExiter.exitCalled) {
+        timeoutOccurred = true
+        break
+      }
+
+      // Only send a status command if we're not close to the max runtime timeout, otherwise we risk
+      // sending the message to a closed socket and causing an exception
+      if (Duration.between(startTime, Instant.now()).seconds < MAX_RUNTIME.seconds - IDLE_TIMEOUT.seconds) {
+        // Postpone idle timeout so we hit the max runtime timeout instead
+        Socket("localhost", daemonData!!.port).use { socket ->
+          socket.getOutputStream().write("status\n".toByteArray())
+          socket.getInputStream().bufferedReader().readText()
+        }
+      }
+      Thread.sleep(100)
+    }
+
+    assertThat(timeoutOccurred).isTrue()
+    assertThat(testExiter.lastExitStatus).isEqualTo(0)
+    // daemon exited because of max runtime timeout, not idle timeout
+    assertThat(Duration.between(startTime, Instant.now()).seconds).isGreaterThan(IDLE_TIMEOUT.seconds)
+  }
+
+  @Test
+  fun `cleans up on stop`() {
+    val lockFile = tempDir.resolve(Daemon.LOCK_FILE_PATH).toFile()
+    assertThat(lockFile.exists()).isTrue()
+
+    daemon.stop()
+
+    // Wait a bit for cleanup
+    Thread.sleep(100)
+
+    assertThat(lockFile.exists()).isFalse()
+    assertThat(daemon.isRunning()).isFalse()
+    assertThat(testExiter.exitCalled).isTrue()
+    assertThat(testExiter.lastExitStatus).isEqualTo(0)
+  }
+
+  @Test
+  fun `handles exit command`() {
+    val daemonData = daemon.readLockFile()
+    assertThat(daemonData).isNotNull
+
+    // Send exit command
+    Socket("localhost", daemonData!!.port).use { socket ->
+      socket.getOutputStream().write("exit\n".toByteArray())
+    }
+
+    // Wait a bit for cleanup
+    Thread.sleep(100)
+
+    assertThat(testExiter.exitCalled).isTrue()
+    assertThat(testExiter.lastExitStatus).isEqualTo(0)
+    assertThat(daemon.isRunning()).isFalse()
+  }
+
+  @Test
+  fun `handles unknown command`() {
+    val daemonData = daemon.readLockFile()
+    assertThat(daemonData).isNotNull
+
+    // Send unknown command
+    Socket("localhost", daemonData!!.port).use { socket ->
+      socket.getOutputStream().write("unknown\n".toByteArray())
+      val reader = socket.getInputStream().bufferedReader()
+      val exitCode = reader.readLine()
+      val output = reader.readText()
+      assertThat(exitCode).isEqualTo(ExitCode.FAILURE.toString())
+      assertThat(output).isEqualTo("Unknown command: unknown")
+    }
+  }
+
+  @Test
+  fun `stops older daemon version when starting new daemon`() {
+    val daemonData = daemon.readLockFile()
+    assertThat(daemonData).isNotNull
+
+    // Start a new daemon with a newer version
+    val newDaemon = Daemon(
+      systemExiter = testExiter,
+      idleTimeout = IDLE_TIMEOUT,
+      maxRuntime = MAX_RUNTIME,
+      timeoutCheckerInterval = TIMEOUT_CHECKER_INTERVAL,
+      workingDir = tempDir,
+      version = 2
+    )
+
+    // Start daemon in a separate thread
+    thread(start = true) {
+      try {
+        newDaemon.start()
+      } catch (e: Exception) {
+        // Ignore exceptions from normal shutdown
+        if (!e.message?.contains("Socket closed")!!) {
+          throw e
+        }
+      }
+    }
+
+    // Wait for new daemon to start (max 1 second)
+    var attempts = 0
+    while (!newDaemon.isRunning() && attempts < 20) {
+      Thread.sleep(50)
+      attempts++
+    }
+
+    assertThat(newDaemon.isRunning()).isTrue()
+
+    // Check that the old daemon has stopped
+    assertThat(daemon.isRunning()).isFalse()
+
+    // Stop the new daemon
+    newDaemon.stop()
+  }
+
+  companion object {
+    val IDLE_TIMEOUT = Duration.ofSeconds(2)
+    val MAX_RUNTIME = Duration.ofSeconds(5)
+    val TIMEOUT_CHECKER_INTERVAL = Duration.ofSeconds(1)
+  }
+}


### PR DESCRIPTION
Adds a daemon mode to the formatter which is long-running and accepts requests to format files. This speeds up the formatting operation by ~1s since we don't have to pay the jar startup cost each time.

I made the existing KotlinFormatter generic so it could be invoked by both the daemon and the cli, and split the cli specfiic operations to a new cli class.