### PR TITLE
Use single git operation to get staged objects for pre-commit

### DIFF
--- a/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/FormattingConfigs.kt
+++ b/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/FormattingConfigs.kt
@@ -48,24 +48,8 @@ internal data class FormattingConfigs private constructor(val formattables: List
         gitRelativePaths = emptyList()
       }
 
-      val stagedFiles =
-        GitStagingService.getStagedFiles()
-          .filter { path -> gitRelativePaths.isEmpty() || gitRelativePaths.any { path.startsWith(it) } }
-          .toSet()
-
-      val unstagedFiles =
-        GitStagingService.getUnstagedFiles()
-          .filter { path -> gitRelativePaths.isEmpty() || gitRelativePaths.any { path.startsWith(it) } }
-          .toSet()
-
-      val formattableBlobs = GitStagingService.getStagedFormattableBlobs(rootPath.toFile(), stagedFiles)
-      val formattableFiles =
-        (stagedFiles - unstagedFiles).map {
-          val absolutePath = rootPath.resolve(it).normalize()
-          FormattableFile(absolutePath.toFile(), rootPath)
-        }
-
-      return formattableBlobs + formattableFiles
+      val formattables = GitStagingService.getStagedFormattableObjects(rootPath, gitRelativePaths)
+      return formattables
     }
 
     private fun expandFileNamesFromCommitted(commitRef: String, paths: List<String>): List<Formattable> {

--- a/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/GitStagingService.kt
+++ b/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/GitStagingService.kt
@@ -24,6 +24,34 @@ internal object GitStagingService {
       .toSet()
   }
 
+  fun getStagedFormattableObjects(gitRoot: Path, pathFilters: List<Path>): List<Formattable> {
+    val formattables = mutableListOf<Formattable>()
+    GitProcessRunner.run("status", "--porcelain=2", "--untracked-files=no", workingDir = gitRoot.toFile()).trim().lines().forEach { line ->
+      val type = line[0]
+      // Only handle modifications or moves; we don't care about unmerged or untracked files
+      if (type == '1' || type == '2') {
+        val tokens = line.split(" ", limit = 9)
+        val modificationType = tokens[1]
+        val stagedModificationType = modificationType[0]
+        val unstagedModificationType = modificationType[1]
+        val modeForIndex = tokens[4]
+        val hashForIndex = tokens[7]
+        val path = Path(tokens[8])
+
+        if (pathFilters.isEmpty() || pathFilters.any { path.startsWith(it) }) {
+          if (stagedModificationType in setOf('A', 'C', 'M', 'R') && path.extension == "kt") {
+            formattables.add(FormattableBlob(path, modeForIndex, hashForIndex))
+            if (unstagedModificationType == '.') {
+              val absolutePath = gitRoot.resolve(path).normalize()
+              formattables.add(FormattableFile(absolutePath.toFile(), gitRoot))
+            }
+          }
+        }
+      }
+    }
+    return formattables
+  }
+
   /** Retrieves a list of [FormattableBlob]s for files that are staged without any merge conflicts. */
   fun getStagedFormattableBlobs(gitRoot: File, stagedPaths: Set<Path>): List<FormattableBlob> {
     val whitespace = Regex("\\s+")

--- a/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/GitStagingService.kt
+++ b/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/GitStagingService.kt
@@ -38,8 +38,8 @@ internal object GitStagingService {
         val hashForIndex = tokens[7]
         val path = Path(tokens[8])
 
-        if (pathFilters.isEmpty() || pathFilters.any { path.startsWith(it) }) {
-          if (stagedModificationType in setOf('A', 'C', 'M', 'R') && path.extension == "kt") {
+        if (stagedModificationType in setOf('A', 'C', 'M', 'R') && path.extension == "kt") {
+          if (pathFilters.isEmpty() || pathFilters.any { path.startsWith(it) }) {
             formattables.add(FormattableBlob(path, modeForIndex, hashForIndex))
             if (unstagedModificationType == '.') {
               val absolutePath = gitRoot.resolve(path).normalize()


### PR DESCRIPTION
On large repos even simple git operations can take a decent amount of time to execute. We've been doing three different git operations to get all the staged objects for pre-commit, which adds up. This PR uses git status porcelain v2 to get all the necessary info in one go and filters through it as needed. On the large repo that I tested it on this runs ~200ms faster than the previous implementation.