### PR TITLE
Use combined file and blob for better performance

### DIFF
--- a/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/FormattableBlobAndFile.kt
+++ b/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/FormattableBlobAndFile.kt
@@ -1,0 +1,25 @@
+package xyz.block.kotlinformatter
+
+/**
+ * A formattable that represents both a Git blob and a file that are in sync
+ * (i.e. when a file is fully staged with no unstaged changes).
+ * This allows for more efficient formatting by reading directly from the file
+ * and writing both to the file and Git blob in one operation.
+ */
+internal class FormattableBlobAndFile(
+    private val blob: FormattableBlob,
+    private val file: FormattableFile,
+) : Formattable {
+    override fun name(): String = file.name()
+
+    override fun read(): String {
+        return file.read()
+    }
+
+    override fun write(content: String) {
+        file.write(content)
+        blob.write(content)
+    }
+
+    fun path() = blob.path
+}

--- a/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/GitStagingService.kt
+++ b/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/GitStagingService.kt
@@ -40,10 +40,14 @@ internal object GitStagingService {
 
         if (stagedModificationType in setOf('A', 'C', 'M', 'R') && path.extension == "kt") {
           if (pathFilters.isEmpty() || pathFilters.any { path.startsWith(it) }) {
-            formattables.add(FormattableBlob(path, modeForIndex, hashForIndex))
+            val absolutePath = gitRoot.resolve(path).normalize()
             if (unstagedModificationType == '.') {
-              val absolutePath = gitRoot.resolve(path).normalize()
-              formattables.add(FormattableFile(absolutePath.toFile(), gitRoot))
+              formattables.add(FormattableBlobAndFile(
+                blob = FormattableBlob(path, modeForIndex, hashForIndex),
+                file = FormattableFile(absolutePath.toFile(), gitRoot),
+              ))
+            } else {
+              formattables.add(FormattableBlob(path, modeForIndex, hashForIndex))
             }
           }
         }

--- a/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/GitStagingService.kt
+++ b/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/GitStagingService.kt
@@ -40,14 +40,15 @@ internal object GitStagingService {
 
         if (stagedModificationType in setOf('A', 'C', 'M', 'R') && path.extension == "kt") {
           if (pathFilters.isEmpty() || pathFilters.any { path.startsWith(it) }) {
-            val absolutePath = gitRoot.resolve(path).normalize()
+            val blob = FormattableBlob(path, modeForIndex, hashForIndex)
             if (unstagedModificationType == '.') {
+              val absolutePath = gitRoot.resolve(path).normalize()
               formattables.add(FormattableBlobAndFile(
-                blob = FormattableBlob(path, modeForIndex, hashForIndex),
+                blob = blob,
                 file = FormattableFile(absolutePath.toFile(), gitRoot),
               ))
             } else {
-              formattables.add(FormattableBlob(path, modeForIndex, hashForIndex))
+              formattables.add(blob)
             }
           }
         }


### PR DESCRIPTION
We use FormattableBlobs to handle formatting git objects directly in the index and FormattableFiles for formatting files on disk. In the case of a fully staged file we have been generating a FormattableBlob and a FormattableFile separately, since both the object in the index and the file on disk match and need to be formatted. This is inefficient since we end up running the formatter twice for the same content. Additionally, it forces a git object read which can be slow in large repos. This PR optimizes this code pathh by introducing a combined FormattableBlobAndFile which reads content from the file, and writes to both the blob and file. 