### PR TITLE
Increase idle and max daemon timeout

### DIFF
--- a/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/Daemon.kt
+++ b/kotlin-format/src/main/kotlin/xyz/block/kotlinformatter/Daemon.kt
@@ -13,8 +13,8 @@ import kotlin.concurrent.thread
 
 class Daemon(
   private val systemExiter: SystemExiter = RealSystemExiter(),
-  private val idleTimeout: Duration = Duration.ofHours(1),
-  private val maxRuntime: Duration = Duration.ofDays(1),
+  private val idleTimeout: Duration = Duration.ofDays(1),
+  private val maxRuntime: Duration = Duration.ofDays(7),
   private val timeoutCheckerInterval: Duration = Duration.ofMinutes(1),
   private val workingDir: Path = rootGitPath,
   private val version: Int = DAEMON_VERSION


### PR DESCRIPTION
Increase the defaults so we restart the daemon less often, and get the benefits more frequently. 