### PR TITLE
Update publication to Sonatype Central Portal 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,8 +36,8 @@ jobs:
     env:
       ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
       ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SECRET_PASSPHRASE }}
-      ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME_XYZ_BLOCK }}
-      ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD_XYZ_BLOCK }}
+      ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_CENTRAL_USERNAME }}
+      ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_CENTRAL_PASSWORD }}
     runs-on: ubuntu-latest
 
     steps:

--- a/kotlin-format/build.gradle.kts
+++ b/kotlin-format/build.gradle.kts
@@ -75,7 +75,7 @@ tasks.register("buildBinary", Sync::class.java) {
 // ----------------------
 mavenPublishing {
   coordinates(group.toString(), artifactName, version.toString())
-  publishToMavenCentral(SonatypeHost.S01, automaticRelease = true)
+  publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
   signAllPublications()
 
   pom {


### PR DESCRIPTION
Related to [internal conversation](https://cash.slack.com/archives/C02FD8Z50/p1746762417526289) on migrating to Sonatype Central Portal. 