### PR TITLE
chore: prepare for release 1.2.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 ### Fixed:
 - Nothing yet!
 
+## [1.2.2] - 2025-05-20
+
+### Changed:
+- Update all non-major dependencies
+- Update publication to Sonatype Central Portal 
+
 ## [1.2.1] - 2025-05-07
 
 ### Fixed:

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ org.gradle.parallel=true
 dependency.analysis.print.build.health=true
 
 group=xyz.block.kotlin-formatter
-version=1.2.1
+version=1.2.2


### PR DESCRIPTION
Releasing a new version to test a new a new publication to Sonatype Central Portal