### PR TITLE
chore: remove deprecated API usage with new maven publish plugin

### DIFF
--- a/kotlin-format/build.gradle.kts
+++ b/kotlin-format/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -75,7 +74,7 @@ tasks.register("buildBinary", Sync::class.java) {
 // ----------------------
 mavenPublishing {
   coordinates(group.toString(), artifactName, version.toString())
-  publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
+  publishToMavenCentral(automaticRelease = true)
   signAllPublications()
 
   pom {


### PR DESCRIPTION
version 0.33.0 defaults to CENTRAL_PORTAL and deprecates usage of SonatypeHost. So we can just drop that and use the default.