### PR TITLE
Unify the test tasks

### DIFF
--- a/kotlin-format/build.gradle.kts
+++ b/kotlin-format/build.gradle.kts
@@ -120,18 +120,9 @@ publishing {
 // Test Configuration
 // ----------------------
 
-tasks.withType<Test>().configureEach { useJUnitPlatform() }
-
-tasks.named("test", Test::class.java).configure {
-  useJUnitPlatform {
-    excludeTags("integration")
-  }
-}
-
-tasks.register("integrationTest", Test::class.java) {
-  useJUnitPlatform {
-    includeTags("integration")
-  }
+tasks.test {
+  useJUnitPlatform()
+  environment("KOTLIN_FORMATTER_STATS", "false")
   dependsOn(shadowJar)
   environment("JAR_UNDER_TEST", shadowJar.map { it.outputs.files.singleFile.absolutePath }.get())
 }

--- a/kotlin-format/src/test/kotlin/xyz/block/kotlinformatter/CliTest.kt
+++ b/kotlin-format/src/test/kotlin/xyz/block/kotlinformatter/CliTest.kt
@@ -257,7 +257,6 @@ class CliTest {
   }
 
   @Test
-  @Tag("integration")
   fun `exercise scenario with file renaming`(@TempDir tempDir: File) {
     val testDir = TestFixtures.setupTestDirectory(tempDir)
     TestUtils.withWorkingDir(testDir.rootDir) {
@@ -277,7 +276,6 @@ class CliTest {
   }
 
   @Test
-  @Tag("integration")
   fun `exercise scenario with file deletion and addition`(@TempDir tempDir: File) {
     val testDir = TestFixtures.setupTestDirectory(tempDir)
     TestUtils.withWorkingDir(testDir.rootDir) {


### PR DESCRIPTION
The custom test task requires more configuration for compatibility with gradle 9, so let's just drop it entirely. There's only two tests that are in that test task, and already they were (I presume accidentally) not getting run. This ensure they run correctly as part of `check`.