### PR TITLE
Suppress another warning when running on newer JDKs

### DIFF
--- a/kotlin-format/build.gradle.kts
+++ b/kotlin-format/build.gradle.kts
@@ -44,7 +44,7 @@ tasks.withType<JavaCompile> {
 
 application {
   mainClass.set("xyz.block.kotlinformatter.CliKt")
-  applicationDefaultJvmArgs = listOf("--enable-native-access=ALL-UNNAMED")
+  applicationDefaultJvmArgs = listOf("--enable-native-access=ALL-UNNAMED", "--sun-misc-unsafe-memory-access=allow")
 }
 
 group = providers.gradleProperty("group").get()


### PR DESCRIPTION
This is coming from kotlinc and we can't fix it ourselves, so suppression is probably the best approach for now. https://github.com/facebook/ktfmt/issues/533